### PR TITLE
Feat : [001] Kakao API 기능 구현 (회원가입 / 로그인 / JWT 토큰발행)

### DIFF
--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthApiClient.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthApiClient.java
@@ -1,0 +1,7 @@
+package com.example.footstep.authentication.oauth;
+
+public interface OAuthApiClient {
+    OAuthProvider oAuthProvider();
+    String requestAccessToken(OAuthLoginParams params);
+    OAuthInfoResponse requestOauthInfo(String accessToken);
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthApiClient.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthApiClient.java
@@ -4,4 +4,6 @@ public interface OAuthApiClient {
     OAuthProvider oAuthProvider();
     String requestAccessToken(OAuthLoginParams params);
     OAuthInfoResponse requestOauthInfo(String accessToken);
+
+
 }

--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthInfoResponse.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthInfoResponse.java
@@ -1,0 +1,67 @@
+package com.example.footstep.authentication.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+public interface OAuthInfoResponse {
+    String getEmail();
+    String getNickName();
+    String getGender();
+    //String getPassword();
+
+    String getImg();
+    OAuthProvider getOAuthProvider();
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoInfoResponse implements OAuthInfoResponse{
+
+        @JsonProperty("kakao_account")
+        private KakaoAccount kakaoAccount;
+
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        static class KakaoAccount {
+            private KakaoProfile profile;
+            private String email;
+            private String gender;
+        }
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        static class KakaoProfile {
+            private String nickname;
+            private String profile_image_url;
+        }
+        @Override
+        public String getEmail() {
+            return kakaoAccount.email;
+        }
+
+        @Override
+        public String getNickName() {
+
+            return kakaoAccount.profile.nickname;
+        }
+
+        @Override
+        public String getGender() {
+            return kakaoAccount.gender;
+        }
+
+        @Override
+        public String getImg() {
+            return kakaoAccount.profile.profile_image_url;
+        }
+
+//        @Override
+//        public String getPassword() {
+//            return null;
+//        }
+
+        @Override
+        public OAuthProvider getOAuthProvider() {
+            return OAuthProvider.KAKAO;
+        }
+    }
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthLoginParams.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthLoginParams.java
@@ -1,0 +1,8 @@
+package com.example.footstep.authentication.oauth;
+
+import org.springframework.util.MultiValueMap;
+
+public interface OAuthLoginParams {
+    OAuthProvider oAuthProvider();
+    MultiValueMap<String, String> makeBody();
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthProvider.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthProvider.java
@@ -1,5 +1,5 @@
 package com.example.footstep.authentication.oauth;
 
 public enum OAuthProvider {
-        KAKAO, GUEST
+        KAKAO, MEMBER
 }

--- a/src/main/java/com/example/footstep/authentication/oauth/OAuthProvider.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.example.footstep.authentication.oauth;
+
+public enum OAuthProvider {
+        KAKAO, GUEST
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoApiClient.java
@@ -1,0 +1,75 @@
+package com.example.footstep.authentication.oauth.kakao;
+
+import com.example.footstep.authentication.oauth.OAuthApiClient;
+import com.example.footstep.authentication.oauth.OAuthInfoResponse;
+import com.example.footstep.authentication.oauth.OAuthLoginParams;
+import com.example.footstep.authentication.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${oauth.kakao.url.auth}")
+    private String authUrl;
+    @Value("${oauth.kakao.url.api}")
+    private String apiUrl ;
+
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    private final RestTemplate restTemplate;
+
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams params) {
+        String url = authUrl + "/oauth/token";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = params.makeBody();
+        body.add("grant_type", GRANT_TYPE);
+        body.add("client_id", clientId);
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        KakaoTokens response = restTemplate.postForObject(url, request, KakaoTokens.class);
+
+        assert response != null;
+        return response.getAccessToken();
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.gender\", \"kakao_account.profile\"]");
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, OAuthInfoResponse.KakaoInfoResponse.class);
+    }
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoApiClient.java
@@ -7,13 +7,20 @@ import com.example.footstep.authentication.oauth.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+
+import org.springframework.core.env.Environment;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 
 @Component
 @RequiredArgsConstructor
@@ -25,13 +32,14 @@ public class KakaoApiClient implements OAuthApiClient {
     private String authUrl;
     @Value("${oauth.kakao.url.api}")
     private String apiUrl ;
-
-
+    @Value("${oauth.kakao.url.unlink}")
+    private String apiUnurl;
     @Value("${oauth.kakao.client-id}")
     private String clientId;
 
     private final RestTemplate restTemplate;
 
+    private final Environment env;
 
     @Override
     public OAuthProvider oAuthProvider() {
@@ -72,4 +80,5 @@ public class KakaoApiClient implements OAuthApiClient {
 
         return restTemplate.postForObject(url, request, OAuthInfoResponse.KakaoInfoResponse.class);
     }
+
 }

--- a/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoLoginParams.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoLoginParams.java
@@ -1,0 +1,26 @@
+package com.example.footstep.authentication.oauth.kakao;
+
+import com.example.footstep.authentication.oauth.OAuthLoginParams;
+import com.example.footstep.authentication.oauth.OAuthProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuthLoginParams {
+    private String authorizationCode;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoTokens.java
+++ b/src/main/java/com/example/footstep/authentication/oauth/kakao/KakaoTokens.java
@@ -1,0 +1,28 @@
+package com.example.footstep.authentication.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokens {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/example/footstep/component/jwt/AuthTokens.java
+++ b/src/main/java/com/example/footstep/component/jwt/AuthTokens.java
@@ -1,0 +1,21 @@
+package com.example.footstep.component.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/com/example/footstep/component/jwt/AuthTokensGenerator.java
+++ b/src/main/java/com/example/footstep/component/jwt/AuthTokensGenerator.java
@@ -1,0 +1,32 @@
+package com.example.footstep.component.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokensGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthTokens generate(Long memberId) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String subject = memberId.toString();
+        String accessToken = jwtTokenProvider.generate(subject, accessTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.generate(subject, refreshTokenExpiredAt);
+
+        return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+
+    public Long extractMemberId(String accessToken) {
+        return Long.valueOf(jwtTokenProvider.extractSubject(accessToken));
+    }
+}

--- a/src/main/java/com/example/footstep/component/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/footstep/component/jwt/JwtTokenProvider.java
@@ -1,0 +1,49 @@
+package com.example.footstep.component.jwt;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret-key}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generate(String subject, Date expiredAt) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String extractSubject(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        return claims.getSubject();
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/example/footstep/component/jwt/RequestOAuthInfoService.java
+++ b/src/main/java/com/example/footstep/component/jwt/RequestOAuthInfoService.java
@@ -1,0 +1,29 @@
+package com.example.footstep.component.jwt;
+
+import com.example.footstep.authentication.oauth.OAuthApiClient;
+import com.example.footstep.authentication.oauth.OAuthInfoResponse;
+import com.example.footstep.authentication.oauth.OAuthLoginParams;
+import com.example.footstep.authentication.oauth.OAuthProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOAuthInfoService {
+    private final Map<OAuthProvider, OAuthApiClient> clients;
+
+    public RequestOAuthInfoService(List<OAuthApiClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthApiClient::oAuthProvider, Function.identity())
+        );
+    }
+
+    public OAuthInfoResponse request(OAuthLoginParams params) {
+        OAuthApiClient client = clients.get(params.oAuthProvider());
+        String accessToken = client.requestAccessToken(params);
+        return client.requestOauthInfo(accessToken);
+    }
+}

--- a/src/main/java/com/example/footstep/config/ClientConfig.java
+++ b/src/main/java/com/example/footstep/config/ClientConfig.java
@@ -1,0 +1,15 @@
+package com.example.footstep.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+
+}

--- a/src/main/java/com/example/footstep/controller/AuthController.java
+++ b/src/main/java/com/example/footstep/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.example.footstep.controller;
+
+import com.example.footstep.component.jwt.AuthTokens;
+import com.example.footstep.authentication.oauth.kakao.KakaoLoginParams;
+import com.example.footstep.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+    private final KakaoService oAuthLoginService;
+
+
+    //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://localhost:8080/api/kakao/callback&response_type=code
+
+    @PostMapping("/auth/kakao")
+    public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams params) {
+        return ResponseEntity.ok(oAuthLoginService.login(params));
+    }
+
+    @ResponseBody
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<String> kakaoCallback(@RequestParam String code){
+        return ResponseEntity.ok(code);
+    }
+
+}

--- a/src/main/java/com/example/footstep/controller/AuthController.java
+++ b/src/main/java/com/example/footstep/controller/AuthController.java
@@ -1,18 +1,21 @@
 package com.example.footstep.controller;
 
+import com.example.footstep.authentication.oauth.kakao.KakaoApiClient;
 import com.example.footstep.component.jwt.AuthTokens;
 import com.example.footstep.authentication.oauth.kakao.KakaoLoginParams;
-import com.example.footstep.service.KakaoService;
+import com.example.footstep.service.impl.KakaoServiceimpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class AuthController {
-    private final KakaoService oAuthLoginService;
-
+    private final KakaoServiceimpl oAuthLoginService;
+    private final KakaoApiClient kakaoApiClient;
 
     //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://localhost:8080/api/kakao/callback&response_type=code
 
@@ -26,5 +29,6 @@ public class AuthController {
     public ResponseEntity<String> kakaoCallback(@RequestParam String code){
         return ResponseEntity.ok(code);
     }
+
 
 }

--- a/src/main/java/com/example/footstep/controller/MemberController.java
+++ b/src/main/java/com/example/footstep/controller/MemberController.java
@@ -1,37 +1,36 @@
 package com.example.footstep.controller;
 
 
+import com.example.footstep.authentication.oauth.kakao.KakaoApiClient;
+import com.example.footstep.authentication.oauth.kakao.KakaoLoginParams;
+import com.example.footstep.component.jwt.AuthTokens;
 import com.example.footstep.component.jwt.AuthTokensGenerator;
 
 import com.example.footstep.domain.entity.Member;
 
+import com.example.footstep.domain.entity.dto.member.LoginDto;
 import com.example.footstep.domain.entity.dto.member.MemberDto;
 import com.example.footstep.domain.entity.repository.MemberRepository;
-import com.example.footstep.service.KakaoService;
+import com.example.footstep.service.SignInService;
 import com.example.footstep.service.SignUpService;
+import com.example.footstep.service.impl.KakaoServiceimpl;
+import com.example.footstep.service.impl.SignUpServiceimpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
+import javax.servlet.http.HttpSession;
+import java.util.HashMap;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
-    private final KakaoService kakaoService;
-    private final SignUpService signUpService;
-//    @GetMapping("/kakao")
-//    public ResponseEntity<Member> kakaoCallback(@RequestParam String code, HttpServletRequest response) throws IOException {
-//        //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://localhost:8080/api/kakao&response_type=code"
-//        //System.out.println(code);
-//        //String access_Token = kakaoService.getKaKaoAccessToken(code);
-//        //kakaoService.createKakaoUser(access_Token);
-//        return ResponseEntity.ok(kakaoService.kakaoLogin(code , response));
-//
-//    }
+    private final KakaoApiClient kakaoApiClient;
+    private final SignInService signInService;
+    private final SignUpServiceimpl signUpService;
+
     private final MemberRepository memberRepository;
     private final AuthTokensGenerator authTokensGenerator;
 
@@ -49,4 +48,11 @@ public class MemberController {
     public ResponseEntity<String> signUpMember(@RequestBody MemberDto memberDto){
         return ResponseEntity.ok(signUpService.memberSignup(memberDto));
     }
+    @PostMapping("/sign-in")
+    public ResponseEntity<AuthTokens> signInMember(@RequestBody LoginDto loginDto){
+        AuthTokens tokens = signInService.login(loginDto);
+
+        return ResponseEntity.ok(tokens);
+    }
+
 }

--- a/src/main/java/com/example/footstep/controller/MemberController.java
+++ b/src/main/java/com/example/footstep/controller/MemberController.java
@@ -1,0 +1,52 @@
+package com.example.footstep.controller;
+
+
+import com.example.footstep.component.jwt.AuthTokensGenerator;
+
+import com.example.footstep.domain.entity.Member;
+
+import com.example.footstep.domain.entity.dto.member.MemberDto;
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import com.example.footstep.service.KakaoService;
+import com.example.footstep.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+    private final KakaoService kakaoService;
+    private final SignUpService signUpService;
+//    @GetMapping("/kakao")
+//    public ResponseEntity<Member> kakaoCallback(@RequestParam String code, HttpServletRequest response) throws IOException {
+//        //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://localhost:8080/api/kakao&response_type=code"
+//        //System.out.println(code);
+//        //String access_Token = kakaoService.getKaKaoAccessToken(code);
+//        //kakaoService.createKakaoUser(access_Token);
+//        return ResponseEntity.ok(kakaoService.kakaoLogin(code , response));
+//
+//    }
+    private final MemberRepository memberRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+
+    @GetMapping
+    public ResponseEntity<List<Member>> findAll() {
+        return ResponseEntity.ok(memberRepository.findAll());
+    }
+
+    @GetMapping("/{accessToken}")
+    public ResponseEntity<Member> findByAccessToken(@PathVariable String accessToken) {
+        Long memberId = authTokensGenerator.extractMemberId(accessToken);
+        return ResponseEntity.ok(memberRepository.findById(memberId).get());
+    }
+    @PostMapping("/sign-up")
+    public ResponseEntity<String> signUpMember(@RequestBody MemberDto memberDto){
+        return ResponseEntity.ok(signUpService.memberSignup(memberDto));
+    }
+}

--- a/src/main/java/com/example/footstep/domain/entity/Member.java
+++ b/src/main/java/com/example/footstep/domain/entity/Member.java
@@ -5,12 +5,15 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
+import com.example.footstep.authentication.oauth.OAuthProvider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.envers.AuditOverride;
+
 
 @Entity
 @Getter
@@ -21,6 +24,7 @@ import org.hibernate.envers.AuditOverride;
 @AuditOverride(forClass = BaseTimeEntity.class)
 public class Member extends BaseTimeEntity {
 
+    // 문제 생기는 컬럼명 gender , password , memberoauth
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
@@ -28,8 +32,13 @@ public class Member extends BaseTimeEntity {
     private String loginEmail;
     @Column(columnDefinition = "NVARCHAR(30) NOT NULL")
     private String nickname;
-    @Column(columnDefinition = "NVARCHAR(255) NOT NULL")
+    @Column(columnDefinition = "NVARCHAR(255)")
     private String password;
-    @Column(columnDefinition = "CHAR(1) NOT NULL")
+    @Column(columnDefinition = "CHAR(30)")
     private String gender;
+
+    @Column(columnDefinition = "NVARCHAR(255)")
+    private String img;
+    @Column( columnDefinition = "NVARCHAR(50)")
+    private OAuthProvider memberOAuth;
 }

--- a/src/main/java/com/example/footstep/domain/entity/dto/member/LoginDto.java
+++ b/src/main/java/com/example/footstep/domain/entity/dto/member/LoginDto.java
@@ -1,0 +1,18 @@
+package com.example.footstep.domain.entity.dto.member;
+
+import lombok.*;
+
+import javax.persistence.Column;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginDto {
+    @Column(columnDefinition = "NVARCHAR(30) NOT NULL")
+    private String loginEmail;
+
+    @Column(columnDefinition = "NVARCHAR(255) NOT NULL")
+    private String password;
+}

--- a/src/main/java/com/example/footstep/domain/entity/dto/member/MemberDto.java
+++ b/src/main/java/com/example/footstep/domain/entity/dto/member/MemberDto.java
@@ -1,0 +1,22 @@
+package com.example.footstep.domain.entity.dto.member;
+
+import com.example.footstep.domain.entity.Member;
+import lombok.*;
+
+import javax.persistence.Column;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDto {
+    @Column(columnDefinition = "NVARCHAR(30) NOT NULL")
+    private String loginEmail;
+    @Column(columnDefinition = "NVARCHAR(30) NOT NULL")
+    private String nickname;
+    @Column(columnDefinition = "NVARCHAR(255) NOT NULL")
+    private String password;
+    @Column(columnDefinition = "CHAR(1) NOT NULL")
+    private String gender;
+
+}

--- a/src/main/java/com/example/footstep/domain/entity/repository/MemberRepository.java
+++ b/src/main/java/com/example/footstep/domain/entity/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.example.footstep.domain.entity.repository;
+
+import com.example.footstep.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> existsByLoginEmail(String email);
+    Optional<Member> findByLoginEmail(String email);
+}

--- a/src/main/java/com/example/footstep/service/KakaoService.java
+++ b/src/main/java/com/example/footstep/service/KakaoService.java
@@ -1,61 +1,9 @@
 package com.example.footstep.service;
 
-import com.example.footstep.component.jwt.RequestOAuthInfoService;
-import com.example.footstep.component.jwt.AuthTokens;
-import com.example.footstep.component.jwt.AuthTokensGenerator;
-import com.example.footstep.authentication.oauth.OAuthInfoResponse;
 import com.example.footstep.authentication.oauth.OAuthLoginParams;
-import com.example.footstep.domain.entity.Member;
+import com.example.footstep.component.jwt.AuthTokens;
 
-import com.example.footstep.domain.entity.repository.MemberRepository;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
+public interface KakaoService {
+    AuthTokens login(OAuthLoginParams params);
 
-
-/*
-**
-파  일  명 : kakaoService
-제작  연도 : 2023.06.07
-작  성  자 : 이대호
-개발 HISTORY
-DATE                  AUTHOR                DESCRIPTION
-------------------+--------------------+--------------------------------------------
-2023-06-7           이대호                 카카오 API 연동 (AccessToken 발급 , 카카오 계정 정보 조회)
-------------------+--------------------+--------------------------------------------
-*/
-@Service
-@AllArgsConstructor
-public class KakaoService {
-        private final MemberRepository memberRepository;
-
-        private final AuthTokensGenerator authTokensGenerator;
-        private final RequestOAuthInfoService requestOAuthInfoService;
-
-        public AuthTokens login(OAuthLoginParams params) {
-            OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
-            Long memberId = findOrCreateMember(oAuthInfoResponse);
-            return authTokensGenerator.generate(memberId);
-        }
-
-        private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
-            return memberRepository.findByLoginEmail(oAuthInfoResponse.getEmail()).map(Member::getMemberId).orElseGet(() -> newMember(oAuthInfoResponse));
-//            if(memberRepository.existsByLoginEmail(oAuthInfoResponse.getEmail()).isPresent()){
-//                return memberRepository.findByLoginEmail(oAuthInfoResponse.getEmail()).get().getMemberId();
-//            }else{
-//                newMember(oAuthInfoResponse);
-//            }
-//            return null;
-        }
-
-        private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
-            Member member = Member.builder()
-                    .loginEmail(oAuthInfoResponse.getEmail())
-                    .nickname(oAuthInfoResponse.getNickName())
-                    .img(oAuthInfoResponse.getImg())
-                    .gender(oAuthInfoResponse.getGender())
-                    .memberOAuth(oAuthInfoResponse.getOAuthProvider())
-                    .build();
-
-            return memberRepository.save(member).getMemberId();
-        }
 }

--- a/src/main/java/com/example/footstep/service/KakaoService.java
+++ b/src/main/java/com/example/footstep/service/KakaoService.java
@@ -1,0 +1,61 @@
+package com.example.footstep.service;
+
+import com.example.footstep.component.jwt.RequestOAuthInfoService;
+import com.example.footstep.component.jwt.AuthTokens;
+import com.example.footstep.component.jwt.AuthTokensGenerator;
+import com.example.footstep.authentication.oauth.OAuthInfoResponse;
+import com.example.footstep.authentication.oauth.OAuthLoginParams;
+import com.example.footstep.domain.entity.Member;
+
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+/*
+**
+파  일  명 : kakaoService
+제작  연도 : 2023.06.07
+작  성  자 : 이대호
+개발 HISTORY
+DATE                  AUTHOR                DESCRIPTION
+------------------+--------------------+--------------------------------------------
+2023-06-7           이대호                 카카오 API 연동 (AccessToken 발급 , 카카오 계정 정보 조회)
+------------------+--------------------+--------------------------------------------
+*/
+@Service
+@AllArgsConstructor
+public class KakaoService {
+        private final MemberRepository memberRepository;
+
+        private final AuthTokensGenerator authTokensGenerator;
+        private final RequestOAuthInfoService requestOAuthInfoService;
+
+        public AuthTokens login(OAuthLoginParams params) {
+            OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
+            Long memberId = findOrCreateMember(oAuthInfoResponse);
+            return authTokensGenerator.generate(memberId);
+        }
+
+        private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
+            return memberRepository.findByLoginEmail(oAuthInfoResponse.getEmail()).map(Member::getMemberId).orElseGet(() -> newMember(oAuthInfoResponse));
+//            if(memberRepository.existsByLoginEmail(oAuthInfoResponse.getEmail()).isPresent()){
+//                return memberRepository.findByLoginEmail(oAuthInfoResponse.getEmail()).get().getMemberId();
+//            }else{
+//                newMember(oAuthInfoResponse);
+//            }
+//            return null;
+        }
+
+        private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
+            Member member = Member.builder()
+                    .loginEmail(oAuthInfoResponse.getEmail())
+                    .nickname(oAuthInfoResponse.getNickName())
+                    .img(oAuthInfoResponse.getImg())
+                    .gender(oAuthInfoResponse.getGender())
+                    .memberOAuth(oAuthInfoResponse.getOAuthProvider())
+                    .build();
+
+            return memberRepository.save(member).getMemberId();
+        }
+}

--- a/src/main/java/com/example/footstep/service/SignInService.java
+++ b/src/main/java/com/example/footstep/service/SignInService.java
@@ -1,0 +1,8 @@
+package com.example.footstep.service;
+
+import com.example.footstep.component.jwt.AuthTokens;
+import com.example.footstep.domain.entity.dto.member.LoginDto;
+
+public interface SignInService {
+    AuthTokens login(LoginDto loginDto);
+}

--- a/src/main/java/com/example/footstep/service/SignUpService.java
+++ b/src/main/java/com/example/footstep/service/SignUpService.java
@@ -1,38 +1,7 @@
 package com.example.footstep.service;
 
-
-
-import com.example.footstep.domain.entity.Member;
-
 import com.example.footstep.domain.entity.dto.member.MemberDto;
-import com.example.footstep.domain.entity.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class SignUpService {
-    private final MemberRepository memberRepository;
-
-    @Transactional
-    public String memberSignup(MemberDto memberDto){
-        if (!memberEmailExist(memberDto.getLoginEmail())){
-            // 에러 코드 생성
-            throw new RuntimeException(); // 추후 에러 컨트롤 핸들러 생성 후 변경
-        }else {
-            //회원가입 추가 테스트
-            Member member = Member.builder()
-                    .loginEmail(memberDto.getLoginEmail())
-                    .password(memberDto.getPassword())
-                    .nickname(memberDto.getNickname())
-                    .gender(memberDto.getGender())
-                    .build();
-            memberRepository.save(member);
-            return "회원가입 성공";
-        }
-    }
-    public boolean memberEmailExist(String email){
-        return memberRepository.existsByLoginEmail(email).isPresent();
-    }
+public interface SignUpService {
+    String memberSignup(MemberDto memberDto);
 }

--- a/src/main/java/com/example/footstep/service/SignUpService.java
+++ b/src/main/java/com/example/footstep/service/SignUpService.java
@@ -1,0 +1,38 @@
+package com.example.footstep.service;
+
+
+
+import com.example.footstep.domain.entity.Member;
+
+import com.example.footstep.domain.entity.dto.member.MemberDto;
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public String memberSignup(MemberDto memberDto){
+        if (!memberEmailExist(memberDto.getLoginEmail())){
+            // 에러 코드 생성
+            throw new RuntimeException(); // 추후 에러 컨트롤 핸들러 생성 후 변경
+        }else {
+            //회원가입 추가 테스트
+            Member member = Member.builder()
+                    .loginEmail(memberDto.getLoginEmail())
+                    .password(memberDto.getPassword())
+                    .nickname(memberDto.getNickname())
+                    .gender(memberDto.getGender())
+                    .build();
+            memberRepository.save(member);
+            return "회원가입 성공";
+        }
+    }
+    public boolean memberEmailExist(String email){
+        return memberRepository.existsByLoginEmail(email).isPresent();
+    }
+}

--- a/src/main/java/com/example/footstep/service/impl/KakaoServiceimpl.java
+++ b/src/main/java/com/example/footstep/service/impl/KakaoServiceimpl.java
@@ -1,0 +1,60 @@
+package com.example.footstep.service.impl;
+
+import com.example.footstep.authentication.oauth.kakao.KakaoApiClient;
+import com.example.footstep.component.jwt.RequestOAuthInfoService;
+import com.example.footstep.component.jwt.AuthTokens;
+import com.example.footstep.component.jwt.AuthTokensGenerator;
+import com.example.footstep.authentication.oauth.OAuthInfoResponse;
+import com.example.footstep.authentication.oauth.OAuthLoginParams;
+import com.example.footstep.domain.entity.Member;
+
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import com.example.footstep.service.KakaoService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+/*
+**
+파  일  명 : kakaoService
+제작  연도 : 2023.06.07
+작  성  자 : 이대호
+개발 HISTORY
+DATE                  AUTHOR                DESCRIPTION
+------------------+--------------------+--------------------------------------------
+2023-06-7           이대호                 카카오 API 연동 (AccessToken 발급 , 카카오 계정 정보 조회)
+------------------+--------------------+--------------------------------------------
+*/
+@Service
+@AllArgsConstructor
+public class KakaoServiceimpl implements KakaoService {
+        private final MemberRepository memberRepository;
+
+        private final AuthTokensGenerator authTokensGenerator;
+        private final RequestOAuthInfoService requestOAuthInfoService;
+        private final KakaoApiClient kakaoApiClient;
+
+        public AuthTokens login(OAuthLoginParams params) {
+            OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
+            Long memberId = findOrCreateMember(oAuthInfoResponse);
+            return authTokensGenerator.generate(memberId);
+        }
+
+        private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
+            return memberRepository.findByLoginEmail(oAuthInfoResponse.getEmail())
+                    .map(Member::getMemberId)
+                    .orElseGet(() -> newMember(oAuthInfoResponse));
+        }
+
+        private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
+            Member member = Member.builder()
+                    .loginEmail(oAuthInfoResponse.getEmail())
+                    .nickname(oAuthInfoResponse.getNickName())
+                    .img(oAuthInfoResponse.getImg())
+                    .gender(oAuthInfoResponse.getGender())
+                    .memberOAuth(oAuthInfoResponse.getOAuthProvider())
+                    .build();
+
+            return memberRepository.save(member).getMemberId();
+        }
+}

--- a/src/main/java/com/example/footstep/service/impl/SignInServiceimpl.java
+++ b/src/main/java/com/example/footstep/service/impl/SignInServiceimpl.java
@@ -1,0 +1,29 @@
+package com.example.footstep.service.impl;
+
+
+import com.example.footstep.component.jwt.AuthTokens;
+import com.example.footstep.component.jwt.AuthTokensGenerator;
+import com.example.footstep.domain.entity.Member;
+import com.example.footstep.domain.entity.dto.member.LoginDto;
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import com.example.footstep.service.SignInService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SignInServiceimpl implements SignInService {
+    private final AuthTokensGenerator authTokensGenerator;
+    private final MemberRepository memberRepository;
+
+
+    @Override
+    public AuthTokens login(LoginDto loginDto) {
+        Long memberId = memberRepository.findByLoginEmail(loginDto.getLoginEmail())
+                .map(Member::getMemberId)
+                .orElseThrow(() -> new RuntimeException());
+        return authTokensGenerator.generate(memberId);
+    }
+}

--- a/src/main/java/com/example/footstep/service/impl/SignUpServiceimpl.java
+++ b/src/main/java/com/example/footstep/service/impl/SignUpServiceimpl.java
@@ -1,0 +1,41 @@
+package com.example.footstep.service.impl;
+
+
+
+import com.example.footstep.authentication.oauth.OAuthProvider;
+import com.example.footstep.domain.entity.Member;
+
+import com.example.footstep.domain.entity.dto.member.MemberDto;
+import com.example.footstep.domain.entity.repository.MemberRepository;
+import com.example.footstep.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpServiceimpl implements SignUpService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public String memberSignup(MemberDto memberDto){
+        if (!memberEmailExist(memberDto.getLoginEmail())){
+            // 에러 코드 생성
+            throw new RuntimeException(); // 추후 에러 컨트롤 핸들러 생성 후 변경
+        }else {
+            //회원가입 추가 테스트
+            Member member = Member.builder()
+                    .loginEmail(memberDto.getLoginEmail())
+                    .password(memberDto.getPassword())
+                    .nickname(memberDto.getNickname())
+                    .gender(memberDto.getGender())
+                    .memberOAuth(OAuthProvider.MEMBER)
+                    .build();
+            memberRepository.save(member);
+            return "회원가입 성공";
+        }
+    }
+    private boolean memberEmailExist(String email){
+        return memberRepository.existsByLoginEmail(email).isPresent();
+    }
+}

--- a/src/test/java/com/example/footstep/FootStepApplicationTests.java
+++ b/src/test/java/com/example/footstep/FootStepApplicationTests.java
@@ -9,6 +9,7 @@ class FootStepApplicationTests {
 	@Test
 	void contextLoads() {
 		System.out.println();
+		System.out.println();
 	}
 
 }

--- a/src/test/java/com/example/footstep/FootStepApplicationTests.java
+++ b/src/test/java/com/example/footstep/FootStepApplicationTests.java
@@ -8,6 +8,7 @@ class FootStepApplicationTests {
 
 	@Test
 	void contextLoads() {
+		System.out.println();
 	}
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성  -->
**AS-IS**
카카오 API 기능 구현 을 통해 카카오로그인시 회원이 아니면 자동 회원가입 기능 구현
회원가입 후 로그인시 accessToken 으로 jwt 토큰을 발행 기능 구현
일반 회원가입 후 로그인시 memberId 로 jwt 토큰발행 기능 구현
**TO-BE**
카카오 회원은 회원탈퇴 시 카카오 API와 연결끊기(회원탈퇴) 기능을 구현해야함
일반회원 탈퇴는 데이터 삭제

로그아웃 기능 또한 같이 구현해야함.

회원가입시 예외 처리 추가
에러 코드 추가
### 테스트 
- [ ] 테스트 코드
- [x] API 테스트 