### PR TITLE
feat : 특정 게시글 조회 기능 최적화

### DIFF
--- a/src/main/java/com/example/footstep/domain/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/footstep/domain/dto/comment/CommentResponseDto.java
@@ -1,5 +1,28 @@
 package com.example.footstep.domain.dto.comment;
 
+import com.example.footstep.domain.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CommentResponseDto {
 
+    private Long commentId;
+    private String memberNickname;
+    private String content;
+
+    public static CommentResponseDto of(Comment comment) {
+        return CommentResponseDto.builder()
+            .commentId(comment.getCommentId())
+            .memberNickname(comment.getMember().getNickname())
+            .content(comment.getContent())
+            .build();
+    }
 }

--- a/src/main/java/com/example/footstep/domain/dto/community/CommunityDetailDto.java
+++ b/src/main/java/com/example/footstep/domain/dto/community/CommunityDetailDto.java
@@ -1,12 +1,14 @@
 package com.example.footstep.domain.dto.community;
 
 import com.example.footstep.domain.dto.comment.CommentResponseDto;
+import com.example.footstep.domain.entity.Comment;
 import com.example.footstep.domain.entity.Community;
 import com.example.footstep.domain.entity.Member;
 import com.example.footstep.domain.entity.ShareRoom;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,14 +39,22 @@ public class CommunityDetailDto {
     private List<CommentResponseDto> comments = new ArrayList<>();
 
     public static CommunityDetailDto of(Community community, Member member,
-                                        ShareRoom shareRoom) {
+                                        ShareRoom shareRoom, List<Comment> comments) {
 
         return CommunityDetailDto.builder()
+            .communityId(community.getCommunityId())
             .communityName(community.getCommunityName())
-            .memberNickname(member.getNickname())
             .likeCount(community.getLikeCount())
             .createdDatetime(community.getCreateDate())
             .content(community.getContent())
+            .memberNickname(member.getNickname())
+            .travelStartDate(shareRoom.getTravelStartDate())
+            .travelEndDate(shareRoom.getTravelEndDate())
+            .commentCount(comments.size())
+            .comments(comments.stream()
+                .map(CommentResponseDto::of)
+                .collect(Collectors.toList())
+            )
             .build();
 
     }

--- a/src/main/java/com/example/footstep/domain/repository/CommentRepository.java
+++ b/src/main/java/com/example/footstep/domain/repository/CommentRepository.java
@@ -1,12 +1,19 @@
 package com.example.footstep.domain.repository;
 
 import com.example.footstep.domain.entity.Comment;
-import com.example.footstep.domain.entity.Community;
 import com.example.footstep.exception.ErrorCode;
 import com.example.footstep.exception.GlobalException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query(value = "select cm "
+        + "from Comment cm "
+        + "left join fetch cm.member "
+        + "where cm.community.communityId = :communityId")
+    List<Comment> findAllByCommunityIdWithMember(Long communityId);
 
     default Comment getCommentById(Long id) {
         return findById(id)

--- a/src/main/java/com/example/footstep/domain/repository/CommunityRepository.java
+++ b/src/main/java/com/example/footstep/domain/repository/CommunityRepository.java
@@ -3,6 +3,7 @@ package com.example.footstep.domain.repository;
 import com.example.footstep.domain.entity.Community;
 import com.example.footstep.exception.ErrorCode;
 import com.example.footstep.exception.GlobalException;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,6 +20,13 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     Slice<Community> findSliceBy(Pageable pageable);
 
     Optional<Community> findByCommunityIdAndMember_MemberId(Long communityId, Long memberId);
+
+    @Query(value = "select c "
+        + "from Community c "
+        + "left join fetch c.member "
+        + "left join fetch c.shareRoom "
+        + "where c.communityId = :id")
+    Optional<Community>findByIdWithShareRoomAndWriter(@Param("id") Long id);
 
     default Community getCommunityById(Long id) {
         return findById(id)

--- a/src/main/java/com/example/footstep/service/CommunityService.java
+++ b/src/main/java/com/example/footstep/service/CommunityService.java
@@ -2,16 +2,19 @@ package com.example.footstep.service;
 
 import com.example.footstep.domain.dto.community.CommunityDetailDto;
 import com.example.footstep.domain.dto.community.CommunityListDto;
+import com.example.footstep.domain.entity.Comment;
 import com.example.footstep.domain.entity.Community;
 import com.example.footstep.domain.entity.Member;
 import com.example.footstep.domain.entity.ShareRoom;
 import com.example.footstep.domain.form.CommunityCreateForm;
 import com.example.footstep.domain.form.CommunityUpdateForm;
+import com.example.footstep.domain.repository.CommentRepository;
 import com.example.footstep.domain.repository.CommunityRepository;
 import com.example.footstep.domain.repository.MemberRepository;
 import com.example.footstep.domain.repository.ShareRoomRepository;
 import com.example.footstep.exception.ErrorCode;
 import com.example.footstep.exception.GlobalException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,6 +28,7 @@ public class CommunityService {
     private final ShareRoomRepository shareRoomRepository;
     private final CommunityRepository communityRepository;
     private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public void create(Long memberId, Long shareId, CommunityCreateForm communityCreateForm) {
@@ -45,10 +49,14 @@ public class CommunityService {
     @Transactional(readOnly = true)
     public CommunityDetailDto getOne(Long communityId) {
 
-        Community community = communityRepository.getCommunityById(communityId);
+        Community community = communityRepository.findByIdWithShareRoomAndWriter(communityId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FIND_COMMUNITY_ID));
+
+        List<Comment> comments = commentRepository.findAllByCommunityIdWithMember(
+            communityId);
 
         return CommunityDetailDto.of(community, community.getMember(),
-            community.getShareRoom());
+            community.getShareRoom(), comments);
 
     }
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Community 내에 있는 Member 와 ShareRoom 정보를 획득할 때 LazyLoading 으로 인해 총 2번의 쿼리가 추가적으로 발생

**TO-BE**
- CommunityRepository 에서 Member 와 ShareRoom 정보를 한 번의 쿼리로 가져올 수 있도록 fetch join 적용
- Comment 의 경우에도 댓글을 작성한 Member 정보가 필요하기 때문에 해당 게시글의 댓글을 단 사람의 수 만큼 쿼리가 나가는 문제 발생해 이 역시 fetch join을 활용해 한번의 쿼리로 가져올 수 있도록 적용


**향후 생각해볼 문제**
- 현재는 게시글의 댓글들을 Community 엔티티에 @OneToMany 해놓지 않은 상태이기 때문에 각각 들고오는 총 2번의 쿼리가 발생
- @OneToMany를 적용해 한번의 쿼리로 가져올 수 있도록 하는 방법 찾아보기 

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 