### PR TITLE
Feat :  JWT 예외 처리 및 refresh token을 통한 새로운 access token 재발급 기능 구현

### DIFF
--- a/src/main/java/com/example/footstep/component/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/footstep/component/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.example.footstep.component.jwt;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -45,13 +46,13 @@ public class JwtTokenProvider {
                 .parseClaimsJws(accessToken)
                 .getBody();
         } catch (SignatureException ex) {
-            throw new SignatureException("invalid token request exception - Incorrect signature");
+            throw new JwtException("invalid token request exception - Incorrect signature");
         } catch (MalformedJwtException ex) {
-            throw new RuntimeException("invalid token request exception - malformed jwt token");
+            throw new JwtException("invalid token request exception - malformed jwt token");
         } catch (ExpiredJwtException ex) {
-            throw new RuntimeException("invalid token request exception - 토큰이 만료. 갱신 필요");
+            throw ex;
         } catch (UnsupportedJwtException ex) {
-            throw new RuntimeException("invalid token request exception - Illegal argument token");
+            throw new JwtException("invalid token request exception - Illegal argument token");
         }
 
         return true;

--- a/src/main/java/com/example/footstep/component/security/JwtExceptionFilter.java
+++ b/src/main/java/com/example/footstep/component/security/JwtExceptionFilter.java
@@ -1,0 +1,68 @@
+package com.example.footstep.component.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            log.warn("토큰 기간 만료 예외 발생 : {}", e.getMessage());
+            setErrorResponse(HttpStatus.UNAUTHORIZED, e.getMessage(), request, response , "EXPIRED_ACCESS_TOKEN");
+        }
+        catch (JwtException e) {
+            log.warn("JWT 예외 발생 : {}", e.getMessage());
+            setErrorResponse(HttpStatus.UNAUTHORIZED, e.getMessage(), request, response, "JWT_EXCEPTION");
+        }
+    }
+
+    private void setErrorResponse(HttpStatus status, String message, HttpServletRequest request, HttpServletResponse response, String code)
+        throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        final Map<String, Object> body = new HashMap<>();
+
+        // 응답 객체 초기화
+        body.put("status", status);
+        body.put("error", "Unauthorized");
+        body.put("message", message);
+        body.put("path", request.getServletPath());
+        body.put("code", code);
+        // response 객체에 응답 객체를 넣어줌
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+
+//    private static class JwtExceptionResponse {
+//
+//        private HttpStatus status;
+//        private String path;
+//        private String message;
+//
+//
+//    }
+}

--- a/src/main/java/com/example/footstep/controller/AuthController.java
+++ b/src/main/java/com/example/footstep/controller/AuthController.java
@@ -3,8 +3,11 @@ package com.example.footstep.controller;
 import com.example.footstep.authentication.oauth.kakao.KakaoLoginParams;
 import com.example.footstep.component.security.AuthTokens;
 import com.example.footstep.service.KakaoService;
+import com.example.footstep.service.TokenService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,13 +16,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class AuthController {
 
     private final KakaoService kakaoService;
-
+    private final TokenService tokenService;
     //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://localhost:8080/api/kakao/callback&response_type=code
 
     //https://kauth.kakao.com/oauth/authorize?client_id=361fc4d12b75888a392207252d5db496&redirect_uri=http://43.200.76.174:8080/api/kakao/callback&response_type=code
@@ -30,7 +34,9 @@ public class AuthController {
     // 로그아웃 리다이렉트 링크
     @PostMapping("/auth/kakao")
     public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams kakaoAccessCode) {
-        return ResponseEntity.ok(kakaoService.login(kakaoAccessCode));
+        AuthTokens authTokens = kakaoService.login(kakaoAccessCode);
+        tokenService.saveRefreshToken(authTokens.getRefreshToken(), authTokens.getJwtAccessToken());
+        return ResponseEntity.ok(authTokens);
     }
     @ResponseBody
     @GetMapping("/kakao/callback")
@@ -45,5 +51,13 @@ public class AuthController {
     @GetMapping("/kakao/logout") // 확인용 추후 삭제될 코드
     public ResponseEntity<String> kakaoLogout(){
         return ResponseEntity.ok("로그아웃");
+    }
+
+    // refresh token을 통해 토큰 재발급
+    @PostMapping("/auth/refresh")
+    public String reIssue(@CookieValue("refresh-token") String refreshToken) {
+        log.info("엑세스 토큰 재발급 시작 : refresh-token : {}", refreshToken);
+        return tokenService.reIssueAccessToken(refreshToken);
+
     }
 }

--- a/src/main/java/com/example/footstep/controller/MemberController.java
+++ b/src/main/java/com/example/footstep/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.example.footstep.domain.form.MemberForm;
 import com.example.footstep.domain.entity.Member;
 import com.example.footstep.domain.repository.MemberRepository;
 
+import com.example.footstep.service.TokenService;
 import java.util.List;
 
 import com.example.footstep.service.MemberService;
@@ -26,6 +27,7 @@ public class MemberController {
 
     private final MemberRepository memberRepository;
     private final AuthTokensGenerator authTokensGenerator;
+    private final TokenService tokenService;
 
     @GetMapping
     public ResponseEntity<List<Member>> getAllMember() {
@@ -46,7 +48,7 @@ public class MemberController {
     @PostMapping("/sign-in")
     public ResponseEntity<AuthTokens> signInMember(@RequestBody @Valid LoginDto loginDto) {
         AuthTokens tokens = memberService.login(loginDto);
-
+        tokenService.saveRefreshToken(tokens.getRefreshToken(), tokens.getJwtAccessToken());
         return ResponseEntity.ok(tokens);
     }
     // 이메일 존재 여부 컨트롤러

--- a/src/main/java/com/example/footstep/domain/entity/RefreshToken.java
+++ b/src/main/java/com/example/footstep/domain/entity/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.example.footstep.domain.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "REFRESH_TOKEN_ID")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String tokenValue;
+
+    public static RefreshToken createRefreshToken(Member member, String tokenValue) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.member = member;
+        refreshToken.tokenValue = tokenValue;
+        return refreshToken;
+    }
+
+}

--- a/src/main/java/com/example/footstep/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/footstep/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.example.footstep.domain.repository;
+
+import com.example.footstep.domain.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    @Query("select rt from RefreshToken rt "
+        + "left join fetch rt.member "
+        + "where rt.tokenValue = :refreshToken")
+    Optional<RefreshToken> findByTokenValueWithMember(String refreshToken);
+}

--- a/src/main/java/com/example/footstep/service/RefreshTokenService.java
+++ b/src/main/java/com/example/footstep/service/RefreshTokenService.java
@@ -1,0 +1,20 @@
+package com.example.footstep.service;
+
+import com.example.footstep.domain.entity.RefreshToken;
+import com.example.footstep.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken findToken(String refreshToken) {
+
+        return refreshTokenRepository.findByTokenValueWithMember(refreshToken)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 토큰입니다."));
+
+    }
+}

--- a/src/main/java/com/example/footstep/service/TokenService.java
+++ b/src/main/java/com/example/footstep/service/TokenService.java
@@ -1,0 +1,59 @@
+package com.example.footstep.service;
+
+import com.example.footstep.component.jwt.JwtTokenProvider;
+import com.example.footstep.domain.entity.Member;
+import com.example.footstep.domain.entity.RefreshToken;
+import com.example.footstep.domain.repository.MemberRepository;
+import com.example.footstep.domain.repository.RefreshTokenRepository;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    @Value("${ACCESS_TOKEN_EXPIRE_TIME}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public String reIssueAccessToken(String refreshToken) {
+
+        // 1) refresh-token 유효성 검사
+        // 2) 유효하면 refresh-token 만료 일자 추출 (나중에 refresh token도 재발급할 때 활용)
+        // 3) DB에서 refresh token 존재 유무 확인
+        RefreshToken findRefreshToken = refreshTokenService.findToken(refreshToken);
+
+        // 4-1) 존재하면 새로운 엑세스 토큰 발급(사용자 정보 (id) 포함)
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+        String newAccessToken = jwtTokenProvider.generate(
+            findRefreshToken.getMember().getMemberId().toString(), accessTokenExpiredAt);
+        // 4-2) 존재하지 않으면 예외 발생(ControllerAdvice 에서 예외처리)
+        //
+
+        return newAccessToken;
+
+    }
+
+    @Transactional
+    public void saveRefreshToken(String refreshToken, String accessToken) {
+
+        String subject = jwtTokenProvider.extractSubject(accessToken);
+
+        Member member = memberRepository.getMemberById(Long.parseLong(subject));
+
+        RefreshToken newRefreshToken = RefreshToken.createRefreshToken(member, refreshToken);
+
+        refreshTokenRepository.save(newRefreshToken);
+    }
+
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**

access token 만료시간이 모두 지났을 경우 새로 로그인 하는 방향으로 구현

**TO-BE**

- access token 이 만료되었을 경우 토큰 만료 관련 예외 응답
  - JwtAuthenticationFilter 에서 토큰 만료 예외, 이외의 예외가 발생할 경우 해당 예외를 처리해줄 JwtExceptionFilter를 추가 
- 로그인(카카오, 일반) 시 refresh token을 DB에 저장
- refresh token 을 통해 새로운 access token 발급 

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 