### PR TITLE
Refactor : 커뮤니티 목록, 상세 응답 DTO 수정 및 게시글 삭제 오류 개선

### DIFF
--- a/src/main/java/com/example/footstep/controller/CommunityController.java
+++ b/src/main/java/com/example/footstep/controller/CommunityController.java
@@ -47,8 +47,10 @@ public class CommunityController {
 
     @GetMapping("/{communityId}")
     public ResponseEntity<CommunityDetailDto> getOneCommunity(
+        @AuthenticationPrincipal LoginMember loginMember,
         @PathVariable Long communityId) {
-        return ResponseEntity.ok(communityService.getOne(communityId));
+
+        return ResponseEntity.ok(communityService.getOne(communityId, loginMember));
 
     }
 

--- a/src/main/java/com/example/footstep/controller/LikeController.java
+++ b/src/main/java/com/example/footstep/controller/LikeController.java
@@ -21,7 +21,7 @@ public class LikeController {
         @AuthenticationPrincipal LoginMember loginMember,
         @PathVariable("id") Long communityId) {
 
-        likeService.likeCommunity(1L, communityId);
+        likeService.likeCommunity(loginMember.getMemberId(), communityId);
 
     }
 
@@ -29,6 +29,8 @@ public class LikeController {
     public void cancelLike(
         @AuthenticationPrincipal LoginMember loginMember,
         @PathVariable("id") Long communityId) {
+
+        likeService.unLikeCommunity(loginMember.getMemberId(), communityId);
 
     }
 }

--- a/src/main/java/com/example/footstep/domain/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/footstep/domain/dto/comment/CommentResponseDto.java
@@ -15,12 +15,14 @@ import lombok.Setter;
 public class CommentResponseDto {
 
     private Long commentId;
+    private Long memberId;
     private String memberNickname;
     private String content;
 
     public static CommentResponseDto of(Comment comment) {
         return CommentResponseDto.builder()
             .commentId(comment.getCommentId())
+            .memberId(comment.getMember().getMemberId())
             .memberNickname(comment.getMember().getNickname())
             .content(comment.getContent())
             .build();

--- a/src/main/java/com/example/footstep/domain/dto/community/CommunityDetailDto.java
+++ b/src/main/java/com/example/footstep/domain/dto/community/CommunityDetailDto.java
@@ -35,11 +35,13 @@ public class CommunityDetailDto {
     private String travelStartDate;
     private String travelEndDate;
 
+    private boolean isLiked;
+
     private int commentCount;
     private List<CommentResponseDto> comments = new ArrayList<>();
 
     public static CommunityDetailDto of(Community community, Member member,
-                                        ShareRoom shareRoom, List<Comment> comments) {
+                                        ShareRoom shareRoom, List<Comment> comments, boolean isLiked) {
 
         return CommunityDetailDto.builder()
             .communityId(community.getCommunityId())
@@ -51,6 +53,7 @@ public class CommunityDetailDto {
             .travelStartDate(shareRoom.getTravelStartDate())
             .travelEndDate(shareRoom.getTravelEndDate())
             .commentCount(comments.size())
+            .isLiked(isLiked)
             .comments(comments.stream()
                 .map(CommentResponseDto::of)
                 .collect(Collectors.toList())

--- a/src/main/java/com/example/footstep/domain/dto/community/CommunityElementDto.java
+++ b/src/main/java/com/example/footstep/domain/dto/community/CommunityElementDto.java
@@ -16,6 +16,7 @@ public class CommunityElementDto {
     private String memberNickname;
     private LocalDateTime createdDate;
     private int likeCount;
+    private boolean communityPublicState;
 
     public static CommunityElementDto from(Community community) {
         return CommunityElementDto.builder()
@@ -24,6 +25,7 @@ public class CommunityElementDto {
             .memberNickname(community.getMember().getNickname())
             .createdDate(community.getCreateDate())
             .likeCount(community.getLikeCount())
+            .communityPublicState(community.isCommunityPublicState())
             .build();
     }
 }

--- a/src/main/java/com/example/footstep/domain/entity/Comment.java
+++ b/src/main/java/com/example/footstep/domain/entity/Comment.java
@@ -13,6 +13,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.envers.AuditOverride;
 
 @Entity
@@ -31,6 +33,7 @@ public class Comment extends BaseTimeEntity {
 
 
     @ManyToOne(fetch = LAZY)
+    @OnDelete(action= OnDeleteAction.CASCADE)
     @JoinColumn(name = "communityId")
     private Community community;
 

--- a/src/main/java/com/example/footstep/domain/entity/Community.java
+++ b/src/main/java/com/example/footstep/domain/entity/Community.java
@@ -49,4 +49,8 @@ public class Community extends BaseTimeEntity {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public boolean isWrittenBy(Long memberId) {
+        return member.getMemberId().equals(memberId);
+    }
 }

--- a/src/main/java/com/example/footstep/domain/repository/CommunityRepository.java
+++ b/src/main/java/com/example/footstep/domain/repository/CommunityRepository.java
@@ -18,6 +18,10 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     @Query("update Community c set c.likeCount = c.likeCount + 1 where c.communityId = :id")
     void increaseLikeCount(Long id);
 
+    @Modifying(clearAutomatically = true)
+    @Query("update Community c set c.likeCount = c.likeCount - 1 where c.communityId = :id")
+    void decreaseLikeCount(Long id);
+
     Slice<Community> findSliceBy(Pageable pageable);
 
     Optional<Community> findByCommunityIdAndMember_MemberId(Long communityId, Long memberId);

--- a/src/main/java/com/example/footstep/domain/repository/LikeRepository.java
+++ b/src/main/java/com/example/footstep/domain/repository/LikeRepository.java
@@ -2,6 +2,7 @@ package com.example.footstep.domain.repository;
 
 import com.example.footstep.domain.entity.Likes;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,4 +12,7 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
         + "where member_id = :memberId", nativeQuery = true)
     List<Long> findCommunityIds(Long memberId);
 
+    boolean existsByCommunity_CommunityIdAndMember_MemberId(Long communityId, Long memberId);
+
+    Optional<Likes> findByCommunity_CommunityIdAndMember_MemberId(Long communityId, Long memberId);
 }

--- a/src/main/java/com/example/footstep/exception/ErrorCode.java
+++ b/src/main/java/com/example/footstep/exception/ErrorCode.java
@@ -32,10 +32,15 @@ public enum ErrorCode {
 
     // 게시글
     NOT_FIND_COMMUNITY_ID("존재하지 않는 게시글 입니다."),
+    UN_MATCHED_MEMBER_AND_COMMUNITY("해당 게시글의 작성자가 아닙니다."),
 
     // 댓글
     NOT_FIND_COMMENT_ID("존재하지 않는 댓글 입니다."),
-    UN_MATCHED_MEMBER_AND_COMMENT("해당 댓글의 작성자가 아닙니다.");
+    UN_MATCHED_MEMBER_AND_COMMENT("해당 댓글의 작성자가 아닙니다."),
+
+    // 좋아요
+    NOT_FIND_LIKE_COMMUNITY("회원이 좋아요한 게시글이 없습니다."),
+    ;
 
     private final String MESSAGE;
 }

--- a/src/main/java/com/example/footstep/service/LikeService.java
+++ b/src/main/java/com/example/footstep/service/LikeService.java
@@ -6,6 +6,8 @@ import com.example.footstep.domain.entity.Member;
 import com.example.footstep.domain.repository.CommunityRepository;
 import com.example.footstep.domain.repository.LikeRepository;
 import com.example.footstep.domain.repository.MemberRepository;
+import com.example.footstep.exception.ErrorCode;
+import com.example.footstep.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,4 +35,16 @@ public class LikeService {
             .build());
     }
 
+    @Transactional
+    public void unLikeCommunity(Long memberId, Long communityId) {
+
+        // 좋아요를 안했는데 좋아요 취소를 눌렀을 경우 예외 처리도 해야하나
+        Likes likes = likeRepository.findByCommunity_CommunityIdAndMember_MemberId(communityId,
+                memberId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FIND_LIKE_COMMUNITY));
+        System.out.println(likes.getLikesId());
+        likeRepository.deleteById(likes.getLikesId());
+        communityRepository.decreaseLikeCount(communityId);
+
+    }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 게시글 삭제 시 댓글과 외래키 연결로 인한 서버 오류 발생

**TO-BE**
- 댓글 엔티티에 @OnDelete 추가
- 게시글 목록 응답 시 publicState 유무 추가 
- 게시글 상세 응답 시 해당 게시글 좋아요 유무 및 댓글 작성자 id 추가

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 