### PR TITLE
Refactor : 정상 회원의 게시글만 조회 

### DIFF
--- a/src/main/java/com/example/footstep/model/dto/community/CommunityListDto.java
+++ b/src/main/java/com/example/footstep/model/dto/community/CommunityListDto.java
@@ -5,24 +5,24 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Page;
 
 @Getter
 @AllArgsConstructor
 public class CommunityListDto {
 
     private List<CommunityElementDto> communities;
-    private boolean lastPage;
+    private int totalPages;
 
 
-    public static CommunityListDto fromSlice(Slice<Community> communities) {
+    public static CommunityListDto from(Page<Community> communities) {
 
         List<CommunityElementDto> postsElementResponses =
             communities.getContent()
-            .stream()
-            .map(CommunityElementDto::from)
-            .collect(Collectors.toList());
+                .stream()
+                .map(CommunityElementDto::from)
+                .collect(Collectors.toList());
 
-        return new CommunityListDto(postsElementResponses, communities.isLast());
+        return new CommunityListDto(postsElementResponses, communities.getTotalPages());
     }
 }

--- a/src/main/java/com/example/footstep/model/repository/CommunityRepository.java
+++ b/src/main/java/com/example/footstep/model/repository/CommunityRepository.java
@@ -3,11 +3,12 @@ package com.example.footstep.model.repository;
 import com.example.footstep.model.entity.Community;
 import com.example.footstep.exception.ErrorCode;
 import com.example.footstep.exception.GlobalException;
+import com.example.footstep.model.entity.MemberStatus;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,8 +23,6 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     @Query("update Community c set c.likeCount = c.likeCount - 1 where c.communityId = :id")
     void decreaseLikeCount(Long id);
 
-    Slice<Community> findSliceBy(Pageable pageable);
-
     Optional<Community> findByCommunityIdAndMember_MemberId(Long communityId, Long memberId);
 
     @Query(value = "select c from Community c "
@@ -37,6 +36,11 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
         + "left join fetch c.shareRoom "
         + "where c.communityId = :id")
     Optional<Community> findByIdWithShareRoomAndMember(@Param("id") Long id);
+
+    @Query(value = "select c from Community c join fetch c.member m where m.memberStatus = :status",
+        countQuery = "select count(c) from Community c join c.member m where m.memberStatus = :status")
+    Page<Community> findAllByMemberStatus(MemberStatus status, Pageable pageable);
+
 
     default Community getCommunityById(Long id) {
         return findById(id)

--- a/src/main/java/com/example/footstep/service/CommunityService.java
+++ b/src/main/java/com/example/footstep/service/CommunityService.java
@@ -6,6 +6,7 @@ import com.example.footstep.model.dto.community.CommunityListDto;
 import com.example.footstep.model.entity.Comment;
 import com.example.footstep.model.entity.Community;
 import com.example.footstep.model.entity.Member;
+import com.example.footstep.model.entity.MemberStatus;
 import com.example.footstep.model.entity.ShareRoom;
 import com.example.footstep.model.form.CommunityCreateForm;
 import com.example.footstep.model.form.CommunityUpdateForm;
@@ -18,8 +19,8 @@ import com.example.footstep.exception.ErrorCode;
 import com.example.footstep.exception.GlobalException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,9 +62,10 @@ public class CommunityService {
     @Transactional(readOnly = true)
     public CommunityListDto getAll(Pageable pageable) {
 
-        Slice<Community> communities = communityRepository.findSliceBy(pageable);
+        Page<Community> communities = communityRepository
+            .findAllByMemberStatus(MemberStatus.NORMAL, pageable);
 
-        return CommunityListDto.fromSlice(communities);
+        return CommunityListDto.from(communities);
     }
 
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 기존에는 탈퇴한 회원의 게시글도 모두 조회
**TO-BE**
- 정상 회원의 게시글만 조회하도록 수정
  - N+1 문제 해결

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 