### PR TITLE
Refactor : 게시글 단건 조회 시 로그인 유무에 따른 로직 처리

### DIFF
--- a/src/main/java/com/example/footstep/component/security/LoginMember.java
+++ b/src/main/java/com/example/footstep/component/security/LoginMember.java
@@ -11,4 +11,6 @@ import java.lang.annotation.Target;
 @Documented
 public @interface LoginMember {
 
+    boolean required() default true;
+
 }

--- a/src/main/java/com/example/footstep/controller/CommunityController.java
+++ b/src/main/java/com/example/footstep/controller/CommunityController.java
@@ -48,7 +48,7 @@ public class CommunityController {
 
     @GetMapping("/{communityId}")
     public ResponseEntity<CommunityDetailDto> getOneCommunity(
-        @LoginMember CurrentMember loginMember,
+        @LoginMember(required = false) CurrentMember loginMember,
         @PathVariable Long communityId) {
 
         return ResponseEntity.ok(communityService.getOne(communityId, loginMember));


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 기존 로직은 인증되지 않은(로그인 하지 않은) 회원이 게시글 단건을 조회하려고 할 경우 예외를 던지도록 구현 

**TO-BE**
- HTTP 헤더에 Authorization 헤더가 없거나 해당 헤더 값이 빈 값이면 먼저 반드시 인증된 사용자인지( required) 검사
  - required 가 true 일 경우 예외 던짐
  - required가 false 일 경우 return null 
- 이 후에는 헤더 값이 정상적인 값이 아닐 경우 예외 던짐
- 해당 로직을 확실히 볼 수 있도록 코드를 리팩토링

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 